### PR TITLE
Upping memory for merge_bam_stats, fixes BIOS-1399

### DIFF
--- a/wdl/tasks/merge_bam_stats.wdl
+++ b/wdl/tasks/merge_bam_stats.wdl
@@ -45,10 +45,11 @@ task merge_bam_stats {
   }
 
   Int threads   = 2
-  Int mem_gb    = 4
+  Int mem_gb    = 10
   Int disk_size = 10
 
   command <<<
+    set -euo pipefail
     zcat ~{sep=" " bam_stats} > ~{sample_id}.read_length_and_quality.tsv
 
     cat << EOF > plot_length_and_quality.py


### PR DESCRIPTION
## Description
To fix issues with memory for `merge_bam_stats`, we are upping the memory for the task from 4GB to 10GB.  Added `set -euo pipefail` to command.

## Dependencies (Issues/PRs)
[BIOS-1399](https://app.clickup.com/t/9014209604/BIOS-1399)

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation

## Task Checklist 
- [ ] documentation updated
- [x] `miniwdl check` passed
- [x] `womtool validate` passed

## Testing
### Workflow Engine Tested On
- [ ] HealthOmics, Amazon Web Services
- [ ] Google Cloud Platform, Cromwell
- [ ] Google Cloud Platform
- [ ] Microsoft Azure, Cromwell
- [ ] GA4GH Workflow Execution Service, On Premises and Multi Cloud
- [ ] Other

### Successful Workflow IDs
*

