### PR TITLE
Fix/pbmm2 jasmine public repo

### DIFF
--- a/wdl/tasks/pbmm2.wdl
+++ b/wdl/tasks/pbmm2.wdl
@@ -65,6 +65,11 @@ task pbmm2_align_wgs {
 
   String movie = basename(bam, ".bam")
 
+  # jasmine is not part of standard quay.io/pacbio container images
+  # a custom image was created using pbmm2 as the base and adding
+  # required tools (i.e. jasmine)
+  String pbmm2_jasmine_docker_image = (if (runtime_attributes.backend == "AWS-HealthOmics") then runtime_attributes.container_registry + "/" else "dnastack/") + "pbmm2_jasmine:1.16.99_2.0.0"
+
   command <<<
     set -euo pipefail
 
@@ -183,7 +188,7 @@ task pbmm2_align_wgs {
   }
 
   runtime {
-    docker: "~{runtime_attributes.container_registry}/pbmm2_jasmine:1.16.99_2.0.0"
+    docker: pbmm2_jasmine_docker_image
     cpu: threads
     memory: mem_gb + " GB"
     disk: disk_size + " GB"


### PR DESCRIPTION
## Description
After creating a new `pbmm2` and `jasmine` container image, there were issues with `hifi-solves-run-humanwgs` identifying the container registry as the default `quay.io/pacbio` doesn't have the image.  Included a statement to handle the  container registry depending on the backend service used.

## Dependencies (Issues/PRs)

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation

## Task Checklist

- [ ] Documentation updated
- [x] `miniwdl check` passed
- [x] `womtool validate` passed

## Testing

### Workflow Engine Tested On

- [ ] HealthOmics, Amazon Web Services
- [x] Google Cloud Platform, Cromwell
- [ ] Google Cloud Platform
- [ ] Microsoft Azure, Cromwell
- [ ] GA4GH Workflow Execution Service, On Premises and Multi Cloud
- [ ] Other

### Successful Workflow IDs

- 99cc926b-13b5-4829-9eb2-5eda1306a44c
