### PR TITLE
Feat: add memory override to pbsv_discover

### DIFF
--- a/wdl/tasks/pbsv.wdl
+++ b/wdl/tasks/pbsv.wdl
@@ -17,6 +17,9 @@ task pbsv_discover {
     trf_bed: {
       name: "Tandem repeat BED used to normalize representation of variation within tandem repeats"
     }
+    pbsv_discover_override_mem_gb: {
+      name: "Memory Allocation Override GB"
+    }
     runtime_attributes: {
       name: "Runtime attribute structure"
     }
@@ -31,11 +34,13 @@ task pbsv_discover {
 
     File? trf_bed
 
+    Int? pbsv_discover_override_mem_gb
+
     RuntimeAttributes runtime_attributes
   }
 
   Int threads   = 2
-  Int mem_gb    = 16
+  Int mem_gb    = select_first([pbsv_discover_override_mem_gb, 16])
   Int disk_size = ceil((size(aligned_bam, "GB") + size(trf_bed, "GB")) * 2 + 20)
 
   String out_prefix = basename(aligned_bam, ".bam")


### PR DESCRIPTION
## Description
Add a memory override input option for `pbsv_discover`.  Note that `pbsv_call` already had a memory override.

## Dependencies (Issues/PRs)
[BIOS-1870](https://app.clickup.com/t/9014209604/BIOS-1870)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation


## Task Checklist
- [ ] documentation updated
- [x] `miniwdl check` passed
- [x] `womtool validate` passed


## Testing
### Workflow Engine Tested On
- [ ] HealthOmics, Amazon Web Services
- [ ] Google Cloud Platform, Cromwell
- [ ] Google Cloud Platform
- [ ] Microsoft Azure, Cromwell
- [ ] GA4GH Workflow Execution Service, On Premises and Multi Cloud
- [ ] Other

### Successful Workflow IDs
*