### PR TITLE
Support non n1 machines

### DIFF
--- a/wdl/structs.wdl
+++ b/wdl/structs.wdl
@@ -11,6 +11,7 @@ struct RuntimeAttributes {
   String zones
 
   String gpuType
+  String cpu_platform
 
   String container_registry
 

--- a/wdl/tasks/bcftools.wdl
+++ b/wdl/tasks/bcftools.wdl
@@ -226,6 +226,7 @@ task bcftools_stats_roh_small_variants {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -304,6 +305,7 @@ task concat_pbsv_vcf {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -393,6 +395,7 @@ task split_vcf_by_sample {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -463,6 +466,7 @@ task bcftools_merge {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -557,5 +561,6 @@ task sv_stats {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/cpg_pileup.wdl
+++ b/wdl/tasks/cpg_pileup.wdl
@@ -133,5 +133,6 @@ task cpg_pileup {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/glnexus.wdl
+++ b/wdl/tasks/glnexus.wdl
@@ -143,5 +143,6 @@ task glnexus {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/hificnv.wdl
+++ b/wdl/tasks/hificnv.wdl
@@ -190,5 +190,6 @@ task hificnv {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/hiphase.wdl
+++ b/wdl/tasks/hiphase.wdl
@@ -215,5 +215,6 @@ task hiphase {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/merge_bam_stats.wdl
+++ b/wdl/tasks/merge_bam_stats.wdl
@@ -116,5 +116,6 @@ task merge_bam_stats {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/mosdepth.wdl
+++ b/wdl/tasks/mosdepth.wdl
@@ -157,5 +157,6 @@ task mosdepth {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/paraphase.wdl
+++ b/wdl/tasks/paraphase.wdl
@@ -90,5 +90,6 @@ task paraphase {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/pbmm2.wdl
+++ b/wdl/tasks/pbmm2.wdl
@@ -238,5 +238,6 @@ task pbmm2_align_wgs {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/pbstarphase.wdl
+++ b/wdl/tasks/pbstarphase.wdl
@@ -93,5 +93,6 @@ task pbstarphase_diplotype {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/pbsv.wdl
+++ b/wdl/tasks/pbsv.wdl
@@ -72,6 +72,7 @@ task pbsv_discover {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -204,5 +205,6 @@ task pbsv_call {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/samtools.wdl
+++ b/wdl/tasks/samtools.wdl
@@ -65,6 +65,7 @@ task samtools_merge {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -122,6 +123,7 @@ task samtools_fasta {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -190,5 +192,6 @@ task samtools_reset {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/trgt.wdl
+++ b/wdl/tasks/trgt.wdl
@@ -150,6 +150,7 @@ task trgt {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -232,6 +233,7 @@ task trgt_merge {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -300,5 +302,6 @@ task coverage_dropouts {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/utilities.wdl
+++ b/wdl/tasks/utilities.wdl
@@ -51,6 +51,7 @@ task split_string {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -122,5 +123,6 @@ task consolidate_stats {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/tasks/write_ped_phrank.wdl
+++ b/wdl/tasks/write_ped_phrank.wdl
@@ -110,5 +110,6 @@ task write_ped_phrank {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/workflows/backend_configuration/backend_configuration.wdl
+++ b/wdl/workflows/backend_configuration/backend_configuration.wdl
@@ -23,6 +23,10 @@ workflow backend_configuration {
     container_registry: {
       help: "Container registry to use"
     }
+    cpu_platform: {
+      help: "Optionally specify a specific cpu_platform to use; GCP only. Cascade and Sky Lake are n2 machines; the rest are n1.",
+      choices: ["Intel Ice Lake", "Intel Cascade Lake", "Intel Skylake", "Intel Broadwell", "Intel Haswell", "Intel Ivy Bridge", "Intel Sandy Bridge"]
+    }
   }
 
   input {
@@ -30,6 +34,7 @@ workflow backend_configuration {
     String? zones
     String? gpuType
     String? container_registry
+    String? cpu_platform
   }
 
   String default_container_registry = "quay.io/pacbio"
@@ -49,6 +54,7 @@ workflow backend_configuration {
       "max_retries": 0,
       "zones": select_first([zones]),
       "gpuType": select_first([gpuType, ""]),
+      "cpu_platform": select_first([cpu_platform, "Intel Sandy Bridge"]),
       "container_registry": select_first([container_registry, default_container_registry])
     }
 
@@ -58,6 +64,7 @@ workflow backend_configuration {
       "max_retries": 0,
       "zones": select_first([zones]),
       "gpuType": select_first([gpuType, ""]),
+      "cpu_platform": select_first([cpu_platform, "Intel Sandy Bridge"]),
       "container_registry": select_first([container_registry, default_container_registry])
     }
   }
@@ -73,6 +80,7 @@ workflow backend_configuration {
       "max_retries": 3,
       "zones": "",
       "gpuType": "",
+      "cpu_platform": "",
       "container_registry": select_first([container_registry, default_container_registry])
     }
 
@@ -82,6 +90,7 @@ workflow backend_configuration {
       "max_retries": 0,
       "zones": "",
       "gpuType": "",
+      "cpu_platform": "",
       "container_registry": select_first([container_registry, default_container_registry])
     }
   }
@@ -102,6 +111,7 @@ workflow backend_configuration {
       "max_retries": 0,
       "zones": "",
       "gpuType": select_first([gpuType, ""]),
+      "cpu_platform": "",
       "container_registry": select_first([container_registry])
     }
   }
@@ -115,6 +125,7 @@ workflow backend_configuration {
       "max_retries": 3,
       "zones": "",
       "gpuType": select_first([gpuType, ""]),
+      "cpu_platform": "",
       "container_registry": select_first([container_registry, default_container_registry])
     }
   }

--- a/wdl/workflows/backend_configuration/backend_configuration.wdl
+++ b/wdl/workflows/backend_configuration/backend_configuration.wdl
@@ -46,7 +46,7 @@ workflow backend_configuration {
     RuntimeAttributes gcp_spot_runtime_attributes = {
       "backend": "GCP",
       "preemptible_tries": 3,
-      "max_retries": 3,
+      "max_retries": 0,
       "zones": select_first([zones]),
       "gpuType": select_first([gpuType, ""]),
       "container_registry": select_first([container_registry, default_container_registry])

--- a/wdl/workflows/backend_configuration/backend_configuration.wdl
+++ b/wdl/workflows/backend_configuration/backend_configuration.wdl
@@ -54,7 +54,7 @@ workflow backend_configuration {
       "max_retries": 0,
       "zones": select_first([zones]),
       "gpuType": select_first([gpuType, ""]),
-      "cpu_platform": select_first([cpu_platform, "Intel Sandy Bridge"]),
+      "cpu_platform": select_first([cpu_platform, "Intel Cascade Lake"]),
       "container_registry": select_first([container_registry, default_container_registry])
     }
 
@@ -64,7 +64,7 @@ workflow backend_configuration {
       "max_retries": 0,
       "zones": select_first([zones]),
       "gpuType": select_first([gpuType, ""]),
-      "cpu_platform": select_first([cpu_platform, "Intel Sandy Bridge"]),
+      "cpu_platform": select_first([cpu_platform, "Intel Cascade Lake"]),
       "container_registry": select_first([container_registry, default_container_registry])
     }
   }

--- a/wdl/workflows/deepvariant/deepvariant.wdl
+++ b/wdl/workflows/deepvariant/deepvariant.wdl
@@ -269,6 +269,7 @@ task deepvariant_make_examples {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -365,6 +366,7 @@ task deepvariant_call_variants_cpu {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -467,6 +469,7 @@ task deepvariant_call_variants_gpu {
     acceleratorCount: 1  # !UnknownRuntimeKey
     acceleratorType: runtime_attributes.gpuType  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -590,5 +593,6 @@ task deepvariant_postprocess_variants {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/workflows/get_pbsv_splits/get_pbsv_splits.wdl
+++ b/wdl/workflows/get_pbsv_splits/get_pbsv_splits.wdl
@@ -87,5 +87,6 @@ task read_pbsv_splits {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }

--- a/wdl/workflows/pharmcat/pharmcat.wdl
+++ b/wdl/workflows/pharmcat/pharmcat.wdl
@@ -214,6 +214,7 @@ task pharmcat_preprocess {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -326,6 +327,7 @@ task filter_preprocessed_vcf {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }
 
@@ -420,5 +422,6 @@ task run_pharmcat {
     maxRetries: runtime_attributes.max_retries
     awsBatchRetryAttempts: runtime_attributes.max_retries  # !UnknownRuntimeKey
     zones: runtime_attributes.zones
+    cpuPlatform: runtime_attributes.cpu_platform
   }
 }


### PR DESCRIPTION
Allows the user to set the cpuPlatform explicitly in GCP. Also updates the default from an n1 machine to n2.

See [here](https://cromwell.readthedocs.io/en/latest/RuntimeAttributes/#cpuplatform) for info on which platforms are supported.

This will allow us to run the workflow in zones that do not have any machine from the default pool type (previously n1, now n2 with these changes).